### PR TITLE
Fix chat_history as an allowed role and expansion of that variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "env": {
+                "LIBRETTO_API_PREFIX": "http://localhost:3000/api",
+            }
+        }
+    ]
+}

--- a/examples/apitest.py
+++ b/examples/apitest.py
@@ -9,7 +9,6 @@ from libretto_openai import (
     LibrettoConfig,
     LibrettoCreateParams,
     TemplateChat,
-    TemplateString,
 )
 
 
@@ -41,21 +40,14 @@ def main():
     )
     print(chat_completion)
 
-    print("TESTING COMPLETION API")
-    completion = client.completions.create(
-        model="text-davinci-003",
-        prompt=TemplateString(template, params),
-        libretto=LibrettoCreateParams(
-            prompt_template_name="test-from-apitest-completion",
-        ),
-    )
-    print(completion)
-
     print("TESTING FEEDBACK")
-    if not completion.model_extra or "libretto_feedback_key" not in completion.model_extra:
+    if (
+        not chat_completion.model_extra
+        or "libretto_feedback_key" not in chat_completion.model_extra
+    ):
         raise Exception("Missing libretto_feedback_key")
     client.send_feedback(
-        feedback_key=completion.model_extra["libretto_feedback_key"],
+        feedback_key=chat_completion.model_extra["libretto_feedback_key"],
         better_response="This response would have been better!",
         rating=0.8,
     )

--- a/examples/chathistory.py
+++ b/examples/chathistory.py
@@ -49,10 +49,15 @@ def main():
                 "coach_question": "Why are you always late to meetings?",
             },
         ),
-        libretto=LibrettoCreateParams(prompt_template_name="weather-report", chat_id="chat-1"),
+        libretto=LibrettoCreateParams(
+            prompt_template_name="chat-history-py-test", chat_id="chat-1"
+        ),
     )
     print(chat_completion)
 
 
 if __name__ == "__main__":
     main()
+
+    # Try to allow the background thread to finish
+    time.sleep(2)

--- a/examples/chathistory.py
+++ b/examples/chathistory.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import logging
+import time
+
+from libretto_openai import (
+    Client,
+    LibrettoConfig,
+    LibrettoCreateParams,
+    TemplateChat,
+)
+
+
+imlogger = logging.getLogger("libretto_openai")
+imlogger.setLevel(logging.DEBUG)
+imlogger.addHandler(logging.StreamHandler())
+
+
+def main():
+    client = Client(
+        libretto=LibrettoConfig(
+            redact_pii=False,
+        )
+    )
+
+    print("TESTING CHAT COMPLETION API w/ LIBRETTO CHAT_HISTORY")
+    chat_completion = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=TemplateChat(
+            [
+                {
+                    "role": "system",
+                    "content": "My role is to be the AI Coach Supervisor to help guide the coach. I will receive a question from the coach, and I will guide them on the content and quality of the question.",
+                },
+                {
+                    "role": "chat_history",
+                    "content": "{prev_messages}",
+                },
+                {
+                    "role": "user",
+                    "content": "{coach_question}",
+                },
+            ],
+            {
+                "prev_messages": [
+                    {"role": "user", "content": "First User message"},
+                    {"role": "assistant", "content": "First response from OpenAI"},
+                ],
+                "coach_question": "Why are you always late to meetings?",
+            },
+        ),
+        libretto=LibrettoCreateParams(prompt_template_name="weather-report", chat_id="chat-1"),
+    )
+    print(chat_completion)
+
+
+if __name__ == "__main__":
+    main()

--- a/libretto_openai/template.py
+++ b/libretto_openai/template.py
@@ -1,6 +1,11 @@
 import re
 from typing import Any, Dict
 
+EXTRACT_PARAM_RE = r"\{(.*?)\}"
+ROLE = "role"
+CONTENT = "content"
+CHAT_HISTORY = "chat_history"
+
 
 class TemplateString(str):
     """Wrapper class for strings that allows us to track parameters."""
@@ -55,18 +60,18 @@ def _format_item(item, params):
 # Returns true of the role of the item is chat_history
 def isLibrettoChatHistory(item):
     if isinstance(item, dict):
-        return item.get("role") == "chat_history"
+        return item.get(ROLE) == CHAT_HISTORY
     return False
 
 
 # Finds the chat_history parameter and returns that param list
 def expandChatHistory(item, params: Dict[str, Any]):
-    content: str = item.get("content")
+    content: str = item.get(CONTENT)
     if not content:
         return []
 
     # Extract the parameter to get the param name
-    all_params = re.findall(r"\{(.*?)\}", content)
+    all_params = re.findall(EXTRACT_PARAM_RE, content)
     if len(all_params) != 1:
         raise RuntimeError(
             "Expected to find one and only one parameter for the chat_history role's content, but found: "

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -15,3 +15,35 @@ def test_template_chat():
     assert template.params == {"name": "John"}
     assert template == [{"role": "system", "content": "Hello John"}]
     assert str(template) == "[{'role': 'system', 'content': 'Hello John'}]"
+
+
+def test_template_chat_with_chat_history():
+    messages = [
+        {
+            "role": "system",
+            "content": "My role is to be the AI Coach Supervisor",
+        },
+        {
+            "role": "chat_history",
+            "content": "{prev_messages}",
+        },
+        {
+            "role": "user",
+            "content": "{coach_question}",
+        },
+    ]
+
+    template = (
+        TemplateChat(
+            messages,
+            {
+                "prev_messages": [
+                    {"role": "user", "content": "First User message"},
+                    {"role": "assistant", "content": "First response from OpenAI"},
+                ],
+                "coach_question": "Why are you always late to meetings?",
+            },
+        ),
+    )[0]
+
+    assert template.template == messages


### PR DESCRIPTION
I think this must have worked at one point, but I think we lost that along the way. This is a similar fix as to what I did in the Typescript one. Only do special handling in a very specific use case (role is chat_history).

Added a unit test and an example to make sure it all works.

<img width="1622" alt="image" src="https://github.com/libretto-ai/openai-py/assets/422315/9c40c859-e7fb-47e3-96a1-09bdc711531c">
