### PR TITLE
Force a version of `typing_requirements` to resolve conflict

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1714,7 +1714,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2635,4 +2634,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "02791508f9d033c9c50438b7758e40986d253453feb6fcbd560ebe6cb508b727"
+content-hash = "020ee1e9d0733725e12cb7c81d05d0f5ddadbf0519a8481483f39ad4e907a74c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ openai = "^1.0.0"
 aiohttp = "^3.8.5"
 presidio-analyzer = "^2.2.33"
 presidio-anonymizer = "^2.2.33"
+typing-extensions = "^4.12.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4,<9.0"


### PR DESCRIPTION
From Render build logs:
```
ERROR: Cannot install -r requirements.txt (line 12), -r requirements.txt (line 26), -r requirements.txt (line 28), -r requirements.txt (line 8) and typing_extensions==4.7.1 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested typing_extensions==4.7.1
    huggingface-hub 0.20.2 depends on typing-extensions>=3.7.4.3
    lightning-utilities 0.9.0 depends on typing-extensions
    temporalio 1.2.0 depends on typing-extensions<5.0.0 and >=4.2.0
    torch 2.2.0 depends on typing-extensions>=4.8.0
```