### PR TITLE
Get toolCalls and rawResponse passed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client = Client(
 
 completion = client.chat.completions.create(
     # Standard OpenAI parameters
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
     messages=TemplateChat(
         [{"role": "user", "content": "Show me an emoji that matches the sport: {sport}"}],
         {"sport": "soccer"},
@@ -94,7 +94,7 @@ While the use of `TemplateText` and `TemplateChat` are preferred, you can option
 
 ```python
 completion = openai.ChatCompletion.create(
-    model="gpt-3.5-turbo",
+    model="gpt-4o-mini",
 
     # Note we are passing the raw messages object here
     messages=[{"role": "user", "content": "Show me an emoji that matches the sport: soccer"}],

--- a/examples/apitest.py
+++ b/examples/apitest.py
@@ -29,7 +29,7 @@ def main():
 
     print("TESTING CHAT COMPLETION API")
     chat_completion = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=TemplateChat(
             [{"role": "user", "content": template}],
             params,
@@ -54,7 +54,7 @@ def main():
 
     print("TESTING CHAT STREAMING API")
     chat_completion_chunks = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=TemplateChat(
             [{"role": "user", "content": template}],
             params,

--- a/examples/chathistory.py
+++ b/examples/chathistory.py
@@ -25,7 +25,7 @@ def main():
 
     print("TESTING CHAT COMPLETION API w/ LIBRETTO CHAT_HISTORY")
     chat_completion = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=TemplateChat(
             [
                 {

--- a/examples/tools.py
+++ b/examples/tools.py
@@ -28,7 +28,7 @@ def main():
 
     print("TESTING CHAT COMPLETION API w/ TOOLS")
     chat_completion = client.chat.completions.create(
-        model="gpt-3.5-turbo-1106",
+        model="gpt-4o-mini",
         messages=TemplateChat(
             [{"role": "user", "content": template}],
             params,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1436,14 +1436,14 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.70.0"
+version = "1.71.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "openai-1.70.0-py3-none-any.whl", hash = "sha256:f6438d053fd8b2e05fd6bef70871e832d9bbdf55e119d0ac5b92726f1ae6f614"},
-    {file = "openai-1.70.0.tar.gz", hash = "sha256:e52a8d54c3efeb08cf58539b5b21a5abef25368b5432965e4de88cdf4e091b2b"},
+    {file = "openai-1.71.0-py3-none-any.whl", hash = "sha256:e1c643738f1fff1af52bce6ef06a7716c95d089281e7011777179614f32937aa"},
+    {file = "openai-1.71.0.tar.gz", hash = "sha256:52b20bb990a1780f9b0b8ccebac93416343ebd3e4e714e3eff730336833ca207"},
 ]
 
 [package.dependencies]
@@ -1458,7 +1458,7 @@ typing-extensions = ">=4.11,<5"
 
 [package.extras]
 datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
-realtime = ["websockets (>=13,<15)"]
+realtime = ["websockets (>=13,<16)"]
 voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 
 [[package]]
@@ -2990,4 +2990,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3bec3fdcc8789fdf4c3e25066e85bf9702957245ebf6f23677831c8cbfdd3633"
+content-hash = "f33827193b3d6bda7327148551f51d12875dc3d87f54e932b8b1dab129f69ef7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-openai = "^1.0.0"
+openai = "^1.71.0"
 aiohttp = "^3.8.5"
 presidio-analyzer = "^2.2.33"
 presidio-anonymizer = "^2.2.33"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,10 @@
 import threading
+from typing import List
 import uuid
 from unittest.mock import ANY, MagicMock, patch
 
 from openai.types import CompletionUsage
-from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat import ChatCompletion, ChatCompletionMessage, ChatCompletionToolParam
 from openai.types.chat.chat_completion import Choice
 import pytest
 
@@ -80,6 +81,91 @@ def test_chat_completion(mock_send_event: MagicMock):
             response_time=ANY,
             feedback_key=ANY,
             tools=None,
+            tool_calls=None,
+            raw_response=ANY,
+        ),
+    )
+
+
+def test_chat_completion_with_tools(mock_send_event: MagicMock):
+    client = Client(api_key="test")
+    client.chat.completions._original_create = MagicMock()
+
+    template = "Send a greeting to our new user named {name}"
+    template_params = {"name": "Alec"}
+    prompt_text = template.format(**template_params)
+    tools: List[ChatCompletionToolParam] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+    chat_template = [{"role": "user", "content": template}]
+    api_key = "alecf-local-playground"
+    prompt_template_name = "test-from-apitest-chat"
+    event_id = str(uuid.uuid4())
+    chain_id = str(uuid.uuid4())
+    chat_id = str(uuid.uuid4())
+    client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "user", "content": prompt_text},
+        ],
+        temperature=0.4,
+        tools=tools,
+        libretto=LibrettoCreateParams(
+            api_key=api_key,
+            prompt_template_name=prompt_template_name,
+            template_chat=chat_template,
+            template_params=template_params,
+            chain_id=chain_id,
+            event_id=event_id,
+            chat_id=chat_id,
+        ),
+    )
+    mock_send_event.send_event_called.wait(1)
+    assert tuple(mock_send_event.call_args_list[0]) == (
+        (ANY),  # session
+        dict(
+            api_key=api_key,
+            prompt_template_name="test-from-apitest-chat",
+            project_key=None,
+            prompt=None,
+            prompt_event_id=event_id,
+            prompt_template_text=None,
+            prompt_template_chat=[
+                {"role": "user", "content": "Send a greeting to our new user named {name}"}
+            ],
+            prompt_params=template_params,
+            chat_id=chat_id,
+            chain_id=chain_id,
+            model_params={
+                "model": "gpt-4o-mini",
+                "modelProvider": "openai",
+                "modelType": "chat",
+                "temperature": 0.4,
+            },
+            response=ANY,
+            response_time=ANY,
+            feedback_key=ANY,
+            tools=tools,
+            tool_calls=None,
+            raw_response=ANY,
         ),
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,7 +39,7 @@ def test_chat_completion(mock_send_event: MagicMock):
     chain_id = str(uuid.uuid4())
     chat_id = str(uuid.uuid4())
     client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=[
             {"role": "user", "content": prompt_text},
         ],
@@ -71,7 +71,7 @@ def test_chat_completion(mock_send_event: MagicMock):
             chat_id=chat_id,
             chain_id=chain_id,
             model_params={
-                "model": "gpt-3.5-turbo",
+                "model": "gpt-4o-mini",
                 "modelProvider": "openai",
                 "modelType": "chat",
                 "temperature": 0.4,
@@ -129,7 +129,7 @@ def test_chat_completion_redact_pii(
         id="chatcmpl-123",
         object="chat.completion",
         created=1677652288,
-        model="gpt-3.5-turbo-0613",
+        model="gpt-4o-mini",
         choices=[
             Choice(
                 index=0,
@@ -149,7 +149,7 @@ def test_chat_completion_redact_pii(
 
     client.chat.completions.create(
         # Standard OpenAI parameters
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=TemplateChat(
             [
                 {"role": "user", "content": "Send a greeting to our new user named {name}"},


### PR DESCRIPTION
This sends up tool_calls separately than the message.content so that we can show both. Also passes up the raw response. See below for an example sent through updated python sdk. 

```
raw_response                 | {"id": "chatcmpl-BK8zx4fLeJCxJkvi3RdFRChCSmekl", "model": "gpt-4o-mini-2024-07-18", "usage": {"total_tokens": 1033, "prompt_tokens": 974, "completion_tokens": 59, "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0}, "completion_tokens_details": {"audio_tokens": 0, "reasoning_tokens": 0, "accepted_prediction_tokens": 0, "rejected_prediction_tokens": 0}}, "object": "chat.completion", "choices": [{"index": 0, "message": {"role": "assistant", "audio": null, "content": "It seems like you're also interested in the weather information; let me show you the current weather for Berkeley.", "refusal": null, "tool_calls": [{"id": "call_FfqjiBL9fMC7eVZQi8TEVL3a", "type": "function", "function": {"name": "decide_component", "arguments": "{\"decision\":true,\"component\":\"WeatherDay\",\"reasoning\":\"The user is asking about the weather information for Berkeley.\"}"}}], "annotations": [], "function_call": null}, "logprobs": null, "finish_reason": "tool_calls"}], "created": 1744140849, "service_tier": "default", "system_fingerprint": "fp_b376dfbbd5", "libretto_feedback_key": "5db56e51-9860-4381-a591-4e21464ba93c"}
libretto_tool_calls_response | {"message":"It seems like you're also interested in the weather information; let me show you the current weather for Berkeley.","tool_calls":[{"id":"call_FfqjiBL9fMC7eVZQi8TEVL3a","type":"function","function":{"arguments":"{\"decision\":true,\"component\":\"WeatherDay\",\"reasoning\":\"The user is asking about the weather information for Berkeley.\"}","name":"decide_component","arguments_parsed":{"decision":true,"component":"WeatherDay","reasoning":"The user is asking about the weather information for Berkeley."}}}]}
```